### PR TITLE
Add optional parameters `write_path` and `read_path` to run_traffic_simulation.py and query_path.py

### DIFF
--- a/projects/bolinas_civic/README.md
+++ b/projects/bolinas_civic/README.md
@@ -41,3 +41,26 @@
             * It will show output "vehicle is on link 543 at 1800 seconds. The end node ID of the current link is 20".
         * `python -c "import query_path; query_path.query_path(vphh=1.5, visitor_cnts=300, player_origin=20, player_destin=193, start_time=1800, end_time=2700)"`
             * It will show output "vehicle is on link 575 at 2700 seconds. The end node ID of the current link is 193".
+4. Optional: Provide the alternative `write_path` paramter to `run_traffic_simulation.py` and `read_path` to `queue_path.py`. This will create/read from new the directory for the following files:
+   
+    ```
+    +-- demand_inputs
+    |   +-- od_csv
+    |       +-- resident_visitor_od_vphh{vphh}_vistor{vistor_cnts}.csv
+    +-- simulation_outputs
+    |   +-- link_weights
+    |       +-- link_speed_vphh{vphh}_vistor{vistor_cnts}.json
+    |   +-- log
+    |       +-- vphh{vphh}_vistor{vistor_cnts}.log
+    |   +-- network
+    |       +-- modified_network_edges_vphh{vphh}_vistor{vistor_cnts}.csv
+    |       +-- network_links.json
+    |       +-- node2link_dict.json
+    ```
+    `read_path` and `write_path` parameters are added to migrate the simulation code to AWS lambda, which has writing restriction for the file system.
+
+    For example,
+   
+   * `python -c "import run_traffic_simulation; run_traffic_simulation.run_traffic_simulation(vphh=1.5, visitor_cnts=300, write_path='/tmp')"` will force the program to write all above files to `/tmp`.
+        
+    * `python -c "import query_path; query_path.query_path(vphh=1.5, visitor_cnts=300, player_origin=143, player_destin=193, start_time=0, end_time=900, read_path='/tmp')"` will read the required files from the directory `/tmp`.

--- a/projects/bolinas_civic/demand_inputs/simple_od.py
+++ b/projects/bolinas_civic/demand_inputs/simple_od.py
@@ -41,7 +41,7 @@ def map_parcels_to_nodes():
     
     return household_parcels, visitor_nodes_gdf
 
-def generate_simple_od(vphh=1, visitor_cnts=0):
+def generate_simple_od(vphh=1, visitor_cnts=0, demand_write_path=None):
     
     household_parcels, visitor_nodes_gdf = map_parcels_to_nodes()
     
@@ -68,5 +68,5 @@ def generate_simple_od(vphh=1, visitor_cnts=0):
     #od_df['destin_osmid'] = np.random.choice(['110360959', '110397253'], size=od_df.shape[0])
     
     ### save to output
-    od_df.to_csv(absolute_path + '/od_csv/resident_visitor_od_vphh{}_visitor{}.csv'.format(vphh, visitor_cnts), index=False)
+    od_df.to_csv(demand_write_path + '/od_csv/resident_visitor_od_vphh{}_visitor{}.csv'.format(vphh, visitor_cnts), index=False)
 

--- a/projects/bolinas_civic/demand_inputs/simple_od.py
+++ b/projects/bolinas_civic/demand_inputs/simple_od.py
@@ -41,7 +41,7 @@ def map_parcels_to_nodes():
     
     return household_parcels, visitor_nodes_gdf
 
-def generate_simple_od(vphh=1, visitor_cnts=0, demand_write_path=None):
+def generate_simple_od(vphh=1, visitor_cnts=0):
     
     household_parcels, visitor_nodes_gdf = map_parcels_to_nodes()
     
@@ -68,5 +68,5 @@ def generate_simple_od(vphh=1, visitor_cnts=0, demand_write_path=None):
     #od_df['destin_osmid'] = np.random.choice(['110360959', '110397253'], size=od_df.shape[0])
     
     ### save to output
-    od_df.to_csv(demand_write_path + '/od_csv/resident_visitor_od_vphh{}_visitor{}.csv'.format(vphh, visitor_cnts), index=False)
+    od_df.to_csv(absolute_path + '/od_csv/resident_visitor_od_vphh{}_visitor{}.csv'.format(vphh, visitor_cnts), index=False)
 

--- a/projects/bolinas_civic/query_path.py
+++ b/projects/bolinas_civic/query_path.py
@@ -22,16 +22,16 @@ def get_route(g, origin, destin):
         sp.clear()
         return route
 
-def query_path(vphh=None, visitor_cnts=None, player_origin=None, player_destin=None, start_time=None, end_time=None):
+def query_path(vphh=None, visitor_cnts=None, player_origin=None, player_destin=None, start_time=None, end_time=None, read_path = None):
 
     ### get graph
-    links_df = pd.read_csv(abs_path + '/simulation_outputs/network/modified_network_edges_vphh{}_visitor{}.csv'.format(vphh, visitor_cnts))
+    links_df = pd.read_csv(read_path + '/simulation_outputs/network/modified_network_edges_vphh{}_visitor{}.csv'.format(vphh, visitor_cnts))
     network_g = interface.from_dataframe(links_df, 'nid_s', 'nid_e', 'fft')
 
-    network_links = json.load(open(abs_path + '/simulation_outputs/network/network_links.json'))
-    node2link_dict = json.load(open(abs_path + '/simulation_outputs/network/node2link_dict.json'))
+    network_links = json.load(open(read_path + '/simulation_outputs/network/network_links.json'))
+    node2link_dict = json.load(open(read_path + '/simulation_outputs/network/node2link_dict.json'))
 
-    link_speed_dict = json.load(open(abs_path + '/simulation_outputs/link_weights/link_speed_vphh{}_visitor{}.json'.format(vphh, visitor_cnts)))
+    link_speed_dict = json.load(open(read_path + '/simulation_outputs/link_weights/link_speed_vphh{}_visitor{}.json'.format(vphh, visitor_cnts)))
     
     current_link = 'n{}_vl'.format(player_origin)
     current_link_distance = 0
@@ -66,3 +66,5 @@ def query_path(vphh=None, visitor_cnts=None, player_origin=None, player_destin=N
             # print('new link {} at {}\n'.format(current_link, t_p))  
     print('vehicle is on link {} at {} seconds. The end node ID of the current link is {}'.format(current_link, end_time, next_node))
     print('Player path nodes {}'.format(player_nodes))
+
+    return player_nodes

--- a/projects/bolinas_civic/queue_class.py
+++ b/projects/bolinas_civic/queue_class.py
@@ -31,7 +31,7 @@ class Network:
         self.agents = {}
         self.agents_stopped = {}
     
-    def dataframe_to_network(self, project_location=None, network_file_edges=None, network_file_nodes=None, cf_files = None, special_nodes=None, scen_nm=None, write_path = None):
+    def dataframe_to_network(self, project_location=None, network_file_edges=None, network_file_nodes=None, cf_files = None, special_nodes=None, scen_nm=None):
         
         # nodes
         print(abs_path)
@@ -65,7 +65,7 @@ class Network:
         # print(links_df.iloc[0])
         # sys.exit(0)
         links_df = links_df[['eid', 'nid_s', 'nid_e', 'type', 'lanes', 'capacity', 'maxmph', 'fft', 'length', 'geometry']]
-        links_df.to_csv(write_path + project_location + '/simulation_outputs/network/modified_network_edges_{}.csv'.format(scen_nm), index=False)
+        links_df.to_csv(abs_path + project_location + '/simulation_outputs/network/modified_network_edges_{}.csv'.format(scen_nm), index=False)
         # sys.exit(0)
         
         ### link closure
@@ -175,13 +175,10 @@ class Network:
                     turning_angle = turning_angle/np.pi*180
                     node.incoming_links[incoming_link][outgoing_link] = turning_angle
     
-    def add_demand(self, demand_files=None, reroute_pct=0, tow_pct=0, write_path = None):
+    def add_demand(self, demand_files=None, reroute_pct=0, tow_pct=0):
         all_od_list = []
-        if not write_path:
-            write_path = abs_path
-        
         for demand_file in demand_files:
-            od = pd.read_csv(write_path + demand_file)
+            od = pd.read_csv(abs_path + demand_file)
             ### transform OSM based id to graph node id
             od['origin_nid'] = od['origin_osmid'].apply(lambda x: self.nodes_osmid_dict[x])
             od['destin_nid'] = od['destin_osmid'].apply(lambda x: self.nodes_osmid_dict[x])

--- a/projects/bolinas_civic/queue_class.py
+++ b/projects/bolinas_civic/queue_class.py
@@ -31,7 +31,7 @@ class Network:
         self.agents = {}
         self.agents_stopped = {}
     
-    def dataframe_to_network(self, project_location=None, network_file_edges=None, network_file_nodes=None, cf_files = None, special_nodes=None, scen_nm=None):
+    def dataframe_to_network(self, project_location=None, network_file_edges=None, network_file_nodes=None, cf_files = None, special_nodes=None, scen_nm=None, write_path = None):
         
         # nodes
         print(abs_path)
@@ -65,7 +65,7 @@ class Network:
         # print(links_df.iloc[0])
         # sys.exit(0)
         links_df = links_df[['eid', 'nid_s', 'nid_e', 'type', 'lanes', 'capacity', 'maxmph', 'fft', 'length', 'geometry']]
-        links_df.to_csv(abs_path + project_location + '/simulation_outputs/network/modified_network_edges_{}.csv'.format(scen_nm), index=False)
+        links_df.to_csv(write_path + project_location + '/simulation_outputs/network/modified_network_edges_{}.csv'.format(scen_nm), index=False)
         # sys.exit(0)
         
         ### link closure
@@ -175,10 +175,13 @@ class Network:
                     turning_angle = turning_angle/np.pi*180
                     node.incoming_links[incoming_link][outgoing_link] = turning_angle
     
-    def add_demand(self, demand_files=None, reroute_pct=0, tow_pct=0):
+    def add_demand(self, demand_files=None, reroute_pct=0, tow_pct=0, write_path = None):
         all_od_list = []
+        if not write_path:
+            write_path = abs_path
+        
         for demand_file in demand_files:
-            od = pd.read_csv(abs_path + demand_file)
+            od = pd.read_csv(write_path + demand_file)
             ### transform OSM based id to graph node id
             od['origin_nid'] = od['origin_osmid'].apply(lambda x: self.nodes_osmid_dict[x])
             od['destin_nid'] = od['destin_osmid'].apply(lambda x: self.nodes_osmid_dict[x])

--- a/projects/bolinas_civic/run_traffic_simulation.py
+++ b/projects/bolinas_civic/run_traffic_simulation.py
@@ -205,4 +205,3 @@ def run_traffic_simulation(vphh=None, visitor_cnts=None, write_path=None):
     with open(write_path+'/simulation_outputs/network/node2link_dict.json', 'w') as outfile:
         json.dump(node2link_dict, outfile, indent=2)
 
-run_traffic_simulation(vphh=1.5, visitor_cnts=300)

--- a/projects/bolinas_civic/run_traffic_simulation.py
+++ b/projects/bolinas_civic/run_traffic_simulation.py
@@ -8,6 +8,8 @@ import pandas as pd
 import geopandas as gpd 
 from shapely.wkt import loads
 
+from pathlib import Path
+
 ### dir
 home_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -20,7 +22,7 @@ random_seed = 0
 random.seed(random_seed)
 np.random.seed(random_seed)
 
-def preparation(vphh=None, visitor_cnts=None, scen_nm=None):
+def preparation(vphh=None, visitor_cnts=None, scen_nm=None, write_path = None):
     ### logging and global variables
 
     network_file_edges = '/network_inputs/bolinas_edges_sim.csv'
@@ -30,7 +32,7 @@ def preparation(vphh=None, visitor_cnts=None, scen_nm=None):
     simulation_outputs = '/simulation_outputs'
 
     scen_nm = scen_nm
-    logging.basicConfig(filename=home_dir+simulation_outputs+'/log/{}.log'.format(scen_nm), filemode='w', format='%(asctime)s - %(message)s', level=logging.INFO, force=True)
+    logging.basicConfig(filename=write_path+simulation_outputs+'/log/{}.log'.format(scen_nm), filemode='w', format='%(asctime)s - %(message)s', level=logging.INFO, force=True)
     logging.info(scen_nm)
     print('log file created for {}'.format(scen_nm))
 
@@ -38,11 +40,11 @@ def preparation(vphh=None, visitor_cnts=None, scen_nm=None):
     with open(home_dir + network_file_special_nodes) as special_nodes_file:
         special_nodes = json.load(special_nodes_file)
     network = Network()
-    network.dataframe_to_network(project_location='', network_file_edges = network_file_edges, network_file_nodes = network_file_nodes, special_nodes=special_nodes, scen_nm=scen_nm)
+    network.dataframe_to_network(project_location='', network_file_edges = network_file_edges, network_file_nodes = network_file_nodes, special_nodes=special_nodes, scen_nm=scen_nm, write_path = write_path)
     network.add_connectivity()
 
     ### demand
-    network.add_demand(demand_files = demand_files)
+    network.add_demand(demand_files = demand_files, write_path = write_path)
     logging.info('total numbers of agents taken {}'.format(len(network.agents.keys())))
 
     return {'network': network}, {'scen_nm': scen_nm, 'simulation_outputs': simulation_outputs, 'special_nodes': special_nodes}, {}
@@ -136,10 +138,28 @@ def one_step(t, data, config, update_data):
     else:
         return network, 'continue'
 
-def run_traffic_simulation(vphh=None, visitor_cnts=None):
+def run_traffic_simulation(vphh=None, visitor_cnts=None, write_path=None):
+    
+    # write_path is the directory mimicing the directory /simulation_outputs
+    if not write_path:
+        write_path = home_dir
+        demand_write_path = home_dir + '/demand_inputs'
+        print("Writing at default project diretory:", write_path)
+    else:
+        demand_write_path = write_path + '/demand_inputs'
+        print("Writing at alternative diretory:", write_path)
+
+    # Check if all directories are ready
+    Path(write_path).mkdir(parents=True, exist_ok=True)
+    Path(write_path + '/simulation_outputs/link_weights').mkdir(parents=True, exist_ok=True)
+    Path(write_path + '/simulation_outputs/log').mkdir(parents=True, exist_ok=True)
+    Path(write_path + '/simulation_outputs/network').mkdir(parents=True, exist_ok=True)
+    Path(demand_write_path).mkdir(parents=True, exist_ok=True)
+    Path(demand_write_path + '/od_csv').mkdir(parents=True, exist_ok=True)
+
 
     ### generate demand
-    generate_simple_od(vphh=vphh, visitor_cnts=visitor_cnts)
+    generate_simple_od(vphh=vphh, visitor_cnts=visitor_cnts, demand_write_path = demand_write_path)
 
     # base network as the base layer of plotting
     roads_df = pd.read_csv(home_dir + '/network_inputs/bolinas_edges_sim.csv')
@@ -148,7 +168,7 @@ def run_traffic_simulation(vphh=None, visitor_cnts=None):
     # set scenario name
     scen_nm = "vphh{}_visitor{}".format(vphh, visitor_cnts)
 
-    data, config, update_data = preparation(vphh=vphh, visitor_cnts=visitor_cnts, scen_nm=scen_nm)
+    data, config, update_data = preparation(vphh=vphh, visitor_cnts=visitor_cnts, scen_nm=scen_nm, write_path = write_path)
 
     link_speed_dict = dict()
     link_vehicles_dict = dict()
@@ -167,13 +187,13 @@ def run_traffic_simulation(vphh=None, visitor_cnts=None):
         link_vehicles_dict[t] = link_vehicles_array
     # print(link_speed_dict[199][0:10])
 
-    with open(home_dir+'/simulation_outputs/link_weights/link_speed_{}.json'.format(scen_nm), 'w') as outfile:
+    with open(write_path+'/simulation_outputs/link_weights/link_speed_{}.json'.format(scen_nm), 'w') as outfile:
         json.dump(link_speed_dict, outfile, indent=2)
     
     network_links_dict = dict()
     for link_id, link in network.links.items():
         network_links_dict[link_id] = {'start_nid': link.start_nid, 'end_nid': link.end_nid, 'length': link.length}
-    with open(home_dir+'/simulation_outputs/network/network_links.json', 'w') as outfile:
+    with open(write_path+'/simulation_outputs/network/network_links.json', 'w') as outfile:
         json.dump(network_links_dict, outfile, indent=2)
 
     node2link_dict = dict()
@@ -182,5 +202,7 @@ def run_traffic_simulation(vphh=None, visitor_cnts=None):
             node2link_dict[start_nid][end_nid] = link_id
         except KeyError:
             node2link_dict[start_nid] = {end_nid: link_id}
-    with open(home_dir+'/simulation_outputs/network/node2link_dict.json', 'w') as outfile:
+    with open(write_path+'/simulation_outputs/network/node2link_dict.json', 'w') as outfile:
         json.dump(node2link_dict, outfile, indent=2)
+
+run_traffic_simulation(vphh=1.5, visitor_cnts=300)

--- a/projects/bolinas_civic/run_traffic_simulation.py
+++ b/projects/bolinas_civic/run_traffic_simulation.py
@@ -8,8 +8,6 @@ import pandas as pd
 import geopandas as gpd 
 from shapely.wkt import loads
 
-from pathlib import Path
-
 ### dir
 home_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -22,7 +20,7 @@ random_seed = 0
 random.seed(random_seed)
 np.random.seed(random_seed)
 
-def preparation(vphh=None, visitor_cnts=None, scen_nm=None, write_path = None):
+def preparation(vphh=None, visitor_cnts=None, scen_nm=None):
     ### logging and global variables
 
     network_file_edges = '/network_inputs/bolinas_edges_sim.csv'
@@ -32,7 +30,7 @@ def preparation(vphh=None, visitor_cnts=None, scen_nm=None, write_path = None):
     simulation_outputs = '/simulation_outputs'
 
     scen_nm = scen_nm
-    logging.basicConfig(filename=write_path+simulation_outputs+'/log/{}.log'.format(scen_nm), filemode='w', format='%(asctime)s - %(message)s', level=logging.INFO, force=True)
+    logging.basicConfig(filename=home_dir+simulation_outputs+'/log/{}.log'.format(scen_nm), filemode='w', format='%(asctime)s - %(message)s', level=logging.INFO, force=True)
     logging.info(scen_nm)
     print('log file created for {}'.format(scen_nm))
 
@@ -40,11 +38,11 @@ def preparation(vphh=None, visitor_cnts=None, scen_nm=None, write_path = None):
     with open(home_dir + network_file_special_nodes) as special_nodes_file:
         special_nodes = json.load(special_nodes_file)
     network = Network()
-    network.dataframe_to_network(project_location='', network_file_edges = network_file_edges, network_file_nodes = network_file_nodes, special_nodes=special_nodes, scen_nm=scen_nm, write_path = write_path)
+    network.dataframe_to_network(project_location='', network_file_edges = network_file_edges, network_file_nodes = network_file_nodes, special_nodes=special_nodes, scen_nm=scen_nm)
     network.add_connectivity()
 
     ### demand
-    network.add_demand(demand_files = demand_files, write_path = write_path)
+    network.add_demand(demand_files = demand_files)
     logging.info('total numbers of agents taken {}'.format(len(network.agents.keys())))
 
     return {'network': network}, {'scen_nm': scen_nm, 'simulation_outputs': simulation_outputs, 'special_nodes': special_nodes}, {}
@@ -138,28 +136,10 @@ def one_step(t, data, config, update_data):
     else:
         return network, 'continue'
 
-def run_traffic_simulation(vphh=None, visitor_cnts=None, write_path=None):
-    
-    # write_path is the directory mimicing the directory /simulation_outputs
-    if not write_path:
-        write_path = home_dir
-        demand_write_path = home_dir + '/demand_inputs'
-        print("Writing at default project diretory:", write_path)
-    else:
-        demand_write_path = write_path + '/demand_inputs'
-        print("Writing at alternative diretory:", write_path)
-
-    # Check if all directories are ready
-    Path(write_path).mkdir(parents=True, exist_ok=True)
-    Path(write_path + '/simulation_outputs/link_weights').mkdir(parents=True, exist_ok=True)
-    Path(write_path + '/simulation_outputs/log').mkdir(parents=True, exist_ok=True)
-    Path(write_path + '/simulation_outputs/network').mkdir(parents=True, exist_ok=True)
-    Path(demand_write_path).mkdir(parents=True, exist_ok=True)
-    Path(demand_write_path + '/od_csv').mkdir(parents=True, exist_ok=True)
-
+def run_traffic_simulation(vphh=None, visitor_cnts=None):
 
     ### generate demand
-    generate_simple_od(vphh=vphh, visitor_cnts=visitor_cnts, demand_write_path = demand_write_path)
+    generate_simple_od(vphh=vphh, visitor_cnts=visitor_cnts)
 
     # base network as the base layer of plotting
     roads_df = pd.read_csv(home_dir + '/network_inputs/bolinas_edges_sim.csv')
@@ -168,7 +148,7 @@ def run_traffic_simulation(vphh=None, visitor_cnts=None, write_path=None):
     # set scenario name
     scen_nm = "vphh{}_visitor{}".format(vphh, visitor_cnts)
 
-    data, config, update_data = preparation(vphh=vphh, visitor_cnts=visitor_cnts, scen_nm=scen_nm, write_path = write_path)
+    data, config, update_data = preparation(vphh=vphh, visitor_cnts=visitor_cnts, scen_nm=scen_nm)
 
     link_speed_dict = dict()
     link_vehicles_dict = dict()
@@ -187,13 +167,13 @@ def run_traffic_simulation(vphh=None, visitor_cnts=None, write_path=None):
         link_vehicles_dict[t] = link_vehicles_array
     # print(link_speed_dict[199][0:10])
 
-    with open(write_path+'/simulation_outputs/link_weights/link_speed_{}.json'.format(scen_nm), 'w') as outfile:
+    with open(home_dir+'/simulation_outputs/link_weights/link_speed_{}.json'.format(scen_nm), 'w') as outfile:
         json.dump(link_speed_dict, outfile, indent=2)
     
     network_links_dict = dict()
     for link_id, link in network.links.items():
         network_links_dict[link_id] = {'start_nid': link.start_nid, 'end_nid': link.end_nid, 'length': link.length}
-    with open(write_path+'/simulation_outputs/network/network_links.json', 'w') as outfile:
+    with open(home_dir+'/simulation_outputs/network/network_links.json', 'w') as outfile:
         json.dump(network_links_dict, outfile, indent=2)
 
     node2link_dict = dict()
@@ -202,7 +182,5 @@ def run_traffic_simulation(vphh=None, visitor_cnts=None, write_path=None):
             node2link_dict[start_nid][end_nid] = link_id
         except KeyError:
             node2link_dict[start_nid] = {end_nid: link_id}
-    with open(write_path+'/simulation_outputs/network/node2link_dict.json', 'w') as outfile:
+    with open(home_dir+'/simulation_outputs/network/node2link_dict.json', 'w') as outfile:
         json.dump(node2link_dict, outfile, indent=2)
-
-run_traffic_simulation(vphh=1.5, visitor_cnts=300)


### PR DESCRIPTION
Hi Bingyu,

I modified the code a little bit by adding a `write_path` paramter to `run_traffic_simulation.py` and `read_path` parameter to `queue_path.py`, to overcome AWS lambda's writing restriction. The parameters are optional and we can still call the functions without specifying the paramters. I am not sure if the changes should be merged to master or any other branches. Feel free to let me know if there's anything I could do.

Best,
Nan